### PR TITLE
Add `nx.config` dict for configuring dispatching and backends

### DIFF
--- a/networkx/__init__.py
+++ b/networkx/__init__.py
@@ -17,7 +17,7 @@ from networkx.lazy_imports import _lazy_import
 from networkx.exception import *
 
 from networkx import utils
-from networkx.utils.backends import _dispatchable
+from networkx.utils.backends import _dispatchable, config
 
 from networkx import classes
 from networkx.classes import filters

--- a/networkx/algorithms/operators/tests/test_binary.py
+++ b/networkx/algorithms/operators/tests/test_binary.py
@@ -53,7 +53,7 @@ def test_intersection():
     assert set(I2.nodes()) == {1, 2, 3, 4}
     assert sorted(I2.edges()) == [(2, 3)]
     # Only test if not performing auto convert testing of backend implementations
-    if not nx.utils.backends._dispatchable._automatic_backends:
+    if not nx.config["backend_priority"]:
         with pytest.raises(TypeError):
             nx.intersection(G2, H)
         with pytest.raises(TypeError):

--- a/networkx/classes/tests/test_backends.py
+++ b/networkx/classes/tests/test_backends.py
@@ -31,8 +31,8 @@ def test_pickle():
 
 
 @pytest.mark.skipif(
-    "not nx._dispatchable._automatic_backends "
-    "or nx._dispatchable._automatic_backends[0] != 'nx-loopback'"
+    "not nx.config['backend_priority'] "
+    "or nx.config['backend_priority'][0] != 'nx-loopback'"
 )
 def test_graph_converter_needs_backend():
     # When testing, `nx.from_scipy_sparse_array` will *always* call the backend

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -45,12 +45,6 @@ def pytest_configure(config):
     backend = config.getoption("--backend")
     if backend is None:
         backend = os.environ.get("NETWORKX_TEST_BACKEND")
-    if backend:
-        networkx.utils.backends._dispatchable._automatic_backends = [backend]
-        fallback_to_nx = config.getoption("--fallback-to-nx")
-        if not fallback_to_nx:
-            fallback_to_nx = os.environ.get("NETWORKX_FALLBACK_TO_NX")
-        networkx.utils.backends._dispatchable._fallback_to_nx = bool(fallback_to_nx)
     # nx-loopback backend is only available when testing
     backends = entry_points(name="nx-loopback", group="networkx.backends")
     if backends:
@@ -64,16 +58,22 @@ def pytest_configure(config):
             "        Try `pip install -e .`, or change your PYTHONPATH\n"
             "        Make sure python finds the networkx repo you are testing\n\n"
         )
+    if backend:
+        networkx.config["backend_priority"] = [backend]
+        fallback_to_nx = config.getoption("--fallback-to-nx")
+        if not fallback_to_nx:
+            fallback_to_nx = os.environ.get("NETWORKX_FALLBACK_TO_NX")
+        networkx.utils.backends._dispatchable._fallback_to_nx = bool(fallback_to_nx)
 
 
 def pytest_collection_modifyitems(config, items):
     # Setting this to True here allows tests to be set up before dispatching
     # any function call to a backend.
     networkx.utils.backends._dispatchable._is_testing = True
-    if automatic_backends := networkx.utils.backends._dispatchable._automatic_backends:
+    if backend_priority := networkx.config["backend_priority"]:
         # Allow pluggable backends to add markers to tests (such as skip or xfail)
         # when running in auto-conversion test mode
-        backend = networkx.utils.backends.backends[automatic_backends[0]].load()
+        backend = networkx.utils.backends.backends[backend_priority[0]].load()
         if hasattr(backend, "on_start_tests"):
             getattr(backend, "on_start_tests")(items)
 

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -106,7 +106,7 @@ import networkx as nx
 from ..exception import NetworkXNotImplemented
 from .decorators import argmap
 
-__all__ = ["_dispatchable"]
+__all__ = ["_dispatchable", "config"]
 
 
 def _do_nothing():
@@ -141,6 +141,31 @@ def _get_backends(group, *, load_and_call=False):
 
 backends = _get_backends("networkx.backends")
 backend_info = _get_backends("networkx.backend_info", load_and_call=True)
+
+# We must import from config after defining `backends` above
+from .configs import Config, config
+
+# Get default configuration from environment variables at import time
+config.backend_priority = [
+    x.strip()
+    for x in os.environ.get(
+        "NETWORKX_BACKEND_PRIORITY",
+        os.environ.get("NETWORKX_AUTOMATIC_BACKENDS", ""),
+    ).split(",")
+    if x.strip()
+]
+# Initialize default configuration for backends
+config.backends = Config(
+    **{
+        backend: (
+            cfg if isinstance(cfg := info["default_config"], Config) else Config(**cfg)
+        )
+        if "default_config" in info
+        else Config()
+        for backend, info in backend_info.items()
+    }
+)
+type(config.backends).__doc__ = "All installed NetworkX backends and their configs."
 
 # Load and cache backends on-demand
 _loaded_backends = {}  # type: ignore[var-annotated]
@@ -180,11 +205,6 @@ class _dispatchable:
     _fallback_to_nx = (
         os.environ.get("NETWORKX_FALLBACK_TO_NX", "true").strip().lower() == "true"
     )
-    _automatic_backends = [
-        x.strip()
-        for x in os.environ.get("NETWORKX_AUTOMATIC_BACKENDS", "").split(",")
-        if x.strip()
-    ]
 
     def __new__(
         cls,
@@ -532,11 +552,12 @@ class _dispatchable:
                     for g in graphs_resolved.values()
                 }
 
-        if self._is_testing and self._automatic_backends and backend_name is None:
+        backend_priority = config.backend_priority
+        if self._is_testing and backend_priority and backend_name is None:
             # Special path if we are running networkx tests with a backend.
             # This even runs for (and handles) functions that mutate input graphs.
             return self._convert_and_call_for_tests(
-                self._automatic_backends[0],
+                backend_priority[0],
                 args,
                 kwargs,
                 fallback_to_nx=self._fallback_to_nx,
@@ -563,7 +584,7 @@ class _dispatchable:
                 raise ImportError(f"Unable to load backend: {graph_backend_name}")
             if (
                 "networkx" in graph_backend_names
-                and graph_backend_name not in self._automatic_backends
+                and graph_backend_name not in backend_priority
             ):
                 # Not configured to convert networkx graphs to this backend
                 raise TypeError(
@@ -584,7 +605,7 @@ class _dispatchable:
                     )
                 # All graphs are backend graphs--no need to convert!
                 return getattr(backend, self.name)(*args, **kwargs)
-            # Future work: try to convert and run with other backends in self._automatic_backends
+            # Future work: try to convert and run with other backends in backend_priority
             raise NetworkXNotImplemented(
                 f"'{self.name}' not implemented by {graph_backend_name}"
             )
@@ -622,7 +643,7 @@ class _dispatchable:
             )
         ):
             # Should we warn or log if we don't convert b/c the input will be mutated?
-            for backend_name in self._automatic_backends:
+            for backend_name in backend_priority:
                 if self._should_backend_run(backend_name, *args, **kwargs):
                     return self._convert_and_call(
                         backend_name,

--- a/networkx/utils/configs.py
+++ b/networkx/utils/configs.py
@@ -1,0 +1,228 @@
+import collections
+import typing
+from dataclasses import dataclass
+
+__all__ = ["Config", "config"]
+
+
+@dataclass(init=False, eq=False, slots=True, kw_only=True, match_args=False)
+class Config:
+    """The base class for NetworkX configuration.
+
+    There are two ways to use this to create configurations. The first is to
+    simply pass the initial configuration as keyword arguments to ``Config``:
+
+    >>> cfg = Config(eggs=1, spam=5)
+    >>> cfg
+    Config(eggs=1, spam=5)
+
+    The second--and preferred--way is to subclass ``Config`` with docs and annotations.
+
+    >>> class MyConfig(Config):
+    ...     '''Breakfast!'''
+    ...
+    ...     eggs: int
+    ...     spam: int
+    ...
+    ...     def _check_config(self, key, value):
+    ...         assert isinstance(value, int) and value >= 0
+    >>> cfg = MyConfig(eggs=1, spam=5)
+
+    Once defined, config items may be modified, but can't be added or deleted by default.
+    ``Config`` is a ``Mapping``, and can get and set configs via attributes or brackets:
+
+    >>> cfg.eggs = 2
+    >>> cfg.eggs
+    2
+    >>> cfg["spam"] = 42
+    >>> cfg["spam"]
+    42
+
+    Subclasses may also define ``_check_config`` (as done in the example above)
+    to ensure the value being assigned is valid:
+
+    >>> cfg.spam = -1
+    Traceback (most recent call last):
+        ...
+    AssertionError
+
+    If a more flexible configuration object is needed that allows adding and deleting
+    configurations, then pass ``strict=False`` when defining the subclass:
+
+    >>> class FlexibleConfig(Config, strict=False):
+    ...     default_greeting: str = "Hello"
+    >>> flexcfg = FlexibleConfig()
+    >>> flexcfg.name = "Mr. Anderson"
+    >>> flexcfg
+    FlexibleConfig(default_greeting='Hello', name='Mr. Anderson')
+    """
+
+    def __init_subclass__(cls, strict=True):
+        cls._strict = strict
+
+    def __new__(cls, **kwargs):
+        orig_class = cls
+        if cls is Config:
+            # Enable the "simple" case of accepting config definition as keywords
+            cls = type(
+                cls.__name__,
+                (cls,),
+                {"__annotations__": {key: typing.Any for key in kwargs}},
+            )
+        cls = dataclass(
+            eq=False,
+            repr=cls._strict,
+            slots=cls._strict,
+            kw_only=True,
+            match_args=False,
+        )(cls)
+        if not cls._strict:
+            cls.__repr__ = _flexible_repr
+        cls._orig_class = orig_class  # Save original class so we can pickle
+        instance = object.__new__(cls)
+        instance.__init__(**kwargs)
+        return instance
+
+    def _check_config(self, key, value):
+        """Check whether config value is valid. This is useful for subclasses."""
+
+    # Control behavior of attributes
+    def __dir__(self):
+        return self.__dataclass_fields__.keys()
+
+    def __setattr__(self, key, value):
+        if self._strict and key not in self.__dataclass_fields__:
+            raise AttributeError(f"Invalid config name: {key!r}")
+        self._check_config(key, value)
+        object.__setattr__(self, key, value)
+
+    def __delattr__(self, key):
+        if self._strict:
+            raise TypeError(
+                f"Configuration items can't be deleted (can't delete {key!r})."
+            )
+        object.__delattr__(self, key)
+
+    # Be a `collection.abc.Collection`
+    def __contains__(self, key):
+        return (
+            key in self.__dataclass_fields__ if self._strict else key in self.__dict__
+        )
+
+    def __iter__(self):
+        return iter(self.__dataclass_fields__ if self._strict else self.__dict__)
+
+    def __len__(self):
+        return len(self.__dataclass_fields__ if self._strict else self.__dict__)
+
+    def __reversed__(self):
+        return reversed(self.__dataclass_fields__ if self._strict else self.__dict__)
+
+    # Add dunder methods for `collections.abc.Mapping`
+    def __getitem__(self, key):
+        try:
+            return getattr(self, key)
+        except AttributeError as err:
+            raise KeyError(*err.args) from None
+
+    def __setitem__(self, key, value):
+        try:
+            setattr(self, key, value)
+        except AttributeError as err:
+            raise KeyError(*err.args) from None
+
+    __delitem__ = __delattr__
+    _ipython_key_completions_ = __dir__  # config["<TAB>
+
+    # Go ahead and make it a `collections.abc.Mapping`
+    def get(self, key, default=None):
+        return getattr(self, key, default)
+
+    def items(self):
+        return collections.abc.ItemsView(self)
+
+    def keys(self):
+        return collections.abc.KeysView(self)
+
+    def values(self):
+        return collections.abc.ValuesView(self)
+
+    # dataclass can define __eq__ for us, but do it here so it works after pickling
+    def __eq__(self, other):
+        if not isinstance(other, Config):
+            return NotImplemented
+        return self._orig_class == other._orig_class and self.items() == other.items()
+
+    # Make pickle work
+    def __reduce__(self):
+        return self._deserialize, (self._orig_class, dict(self))
+
+    @staticmethod
+    def _deserialize(cls, kwargs):
+        return cls(**kwargs)
+
+
+def _flexible_repr(self):
+    return (
+        f"{self.__class__.__qualname__}("
+        + ", ".join(f"{key}={val!r}" for key, val in self.__dict__.items())
+        + ")"
+    )
+
+
+# Register, b/c `Mapping.__subclasshook__` returns `NotImplemented`
+collections.abc.Mapping.register(Config)
+
+
+class NetworkXConfig(Config):
+    """Configuration for NetworkX that controls behaviors such as how to use backends.
+
+    Attribute and bracket notation are supported for getting and setting configurations:
+
+    >>> nx.config.backend_priority == nx.config["backend_priority"]
+    True
+
+    Config Parameters
+    -----------------
+    backend_priority : list of backend names
+        Enable automatic conversion of graphs to backend graphs for algorithms
+        implemented by the backend. Priority is given to backends listed earlier.
+
+    backends : Config mapping of backend names to backend Config
+        The keys of the Config mapping are names of all installed NetworkX backends,
+        and the values are their configurations as Config mappings.
+    """
+
+    backend_priority: list[str]
+    backends: Config
+
+    def _check_config(self, key, value):
+        from .backends import backends
+
+        if key == "backend_priority":
+            if not (isinstance(value, list) and all(isinstance(x, str) for x in value)):
+                raise TypeError(
+                    f"{key!r} config must be a list of backend names; got {value!r}"
+                )
+            if missing := {x for x in value if x not in backends}:
+                missing = ", ".join(map(repr, sorted(missing)))
+                raise ValueError(f"Unknown backend when setting {key!r}: {missing}")
+        elif key == "backends":
+            if not (
+                isinstance(value, Config)
+                and all(isinstance(key, str) for key in value)
+                and all(isinstance(val, Config) for val in value.values())
+            ):
+                raise TypeError(
+                    f"{key!r} config must be a Config of backend configs; got {value!r}"
+                )
+            if missing := {x for x in value if x not in backends}:
+                missing = ", ".join(map(repr, sorted(missing)))
+                raise ValueError(f"Unknown backend when setting {key!r}: {missing}")
+
+
+# Backend configuration will be updated in backends.py
+config = NetworkXConfig(
+    backend_priority=[],
+    backends=Config(),
+)

--- a/networkx/utils/tests/test_config.py
+++ b/networkx/utils/tests/test_config.py
@@ -1,0 +1,180 @@
+import collections
+import pickle
+
+import pytest
+
+import networkx as nx
+from networkx.utils.configs import Config
+
+
+# Define this at module level so we can test pickling
+class ExampleConfig(Config):
+    """Example configuration."""
+
+    x: int
+    y: str
+
+    def _check_config(self, key, value):
+        if key == "x" and value <= 0:
+            raise ValueError("x must be positive")
+        if key == "y" and not isinstance(value, str):
+            raise TypeError("y must be a str")
+
+
+class EmptyConfig(Config):
+    pass
+
+
+@pytest.mark.parametrize("cfg", [EmptyConfig(), Config()])
+def test_config_empty(cfg):
+    assert dir(cfg) == []
+    with pytest.raises(AttributeError):
+        cfg.x = 1
+    with pytest.raises(KeyError):
+        cfg["x"] = 1
+    with pytest.raises(AttributeError):
+        cfg.x
+    with pytest.raises(KeyError):
+        cfg["x"]
+    assert len(cfg) == 0
+    assert "x" not in cfg
+    assert cfg == cfg
+    assert cfg.get("x", 2) == 2
+    assert set(cfg.keys()) == set()
+    assert set(cfg.values()) == set()
+    assert set(cfg.items()) == set()
+    cfg2 = pickle.loads(pickle.dumps(cfg))
+    assert cfg == cfg2
+    assert isinstance(cfg, collections.abc.Collection)
+    assert isinstance(cfg, collections.abc.Mapping)
+
+
+def test_config_subclass():
+    with pytest.raises(TypeError, match="missing 2 required keyword-only"):
+        ExampleConfig()
+    with pytest.raises(ValueError, match="x must be positive"):
+        ExampleConfig(x=0, y="foo")
+    with pytest.raises(TypeError, match="unexpected keyword"):
+        ExampleConfig(x=1, y="foo", z="bad config")
+    with pytest.raises(TypeError, match="unexpected keyword"):
+        EmptyConfig(z="bad config")
+    cfg = ExampleConfig(x=1, y="foo")
+    assert cfg.x == 1
+    assert cfg["x"] == 1
+    assert cfg["y"] == "foo"
+    assert cfg.y == "foo"
+    assert "x" in cfg
+    assert "y" in cfg
+    assert "z" not in cfg
+    assert len(cfg) == 2
+    assert set(iter(cfg)) == {"x", "y"}
+    assert set(cfg.keys()) == {"x", "y"}
+    assert set(cfg.values()) == {1, "foo"}
+    assert set(cfg.items()) == {("x", 1), ("y", "foo")}
+    assert dir(cfg) == ["x", "y"]
+    cfg.x = 2
+    cfg["y"] = "bar"
+    assert cfg["x"] == 2
+    assert cfg.y == "bar"
+    with pytest.raises(TypeError, match="can't be deleted"):
+        del cfg.x
+    with pytest.raises(TypeError, match="can't be deleted"):
+        del cfg["y"]
+    assert cfg.x == 2
+    assert cfg == cfg
+    assert cfg == ExampleConfig(x=2, y="bar")
+    assert cfg != ExampleConfig(x=3, y="baz")
+    assert cfg != Config(x=2, y="bar")
+    with pytest.raises(TypeError, match="y must be a str"):
+        cfg["y"] = 5
+    with pytest.raises(ValueError, match="x must be positive"):
+        cfg.x = -5
+    assert cfg.get("x", 10) == 2
+    with pytest.raises(AttributeError):
+        cfg.z = 5
+    with pytest.raises(KeyError):
+        cfg["z"] = 5
+    with pytest.raises(AttributeError):
+        cfg.z
+    with pytest.raises(KeyError):
+        cfg["z"]
+    cfg2 = pickle.loads(pickle.dumps(cfg))
+    assert cfg == cfg2
+    assert cfg.__doc__ == "Example configuration."
+    assert cfg2.__doc__ == "Example configuration."
+
+
+def test_config_defaults():
+    class DefaultConfig(Config):
+        x: int = 0
+        y: int
+
+    cfg = DefaultConfig(y=1)
+    assert cfg.x == 0
+    cfg = DefaultConfig(x=2, y=1)
+    assert cfg.x == 2
+
+
+def test_nxconfig():
+    assert isinstance(nx.config.backend_priority, list)
+    assert isinstance(nx.config.backends, Config)
+    with pytest.raises(TypeError, match="must be a list of backend names"):
+        nx.config.backend_priority = "nx_loopback"
+    with pytest.raises(ValueError, match="Unknown backend when setting"):
+        nx.config.backend_priority = ["this_almost_certainly_is_not_a_backend"]
+    with pytest.raises(TypeError, match="must be a Config of backend configs"):
+        nx.config.backends = {}
+    with pytest.raises(TypeError, match="must be a Config of backend configs"):
+        nx.config.backends = Config(plausible_backend_name={})
+    with pytest.raises(ValueError, match="Unknown backend when setting"):
+        nx.config.backends = Config(this_almost_certainly_is_not_a_backend=Config())
+
+
+def test_not_strict():
+    class FlexibleConfig(Config, strict=False):
+        x: int
+
+    cfg = FlexibleConfig(x=1)
+    assert "_strict" not in cfg
+    assert len(cfg) == 1
+    assert list(cfg) == ["x"]
+    assert list(cfg.keys()) == ["x"]
+    assert list(cfg.values()) == [1]
+    assert list(cfg.items()) == [("x", 1)]
+    assert cfg.x == 1
+    assert cfg["x"] == 1
+    assert "x" in cfg
+    assert hasattr(cfg, "x")
+    assert "FlexibleConfig(x=1)" in repr(cfg)
+    assert cfg == FlexibleConfig(x=1)
+    del cfg.x
+    assert "FlexibleConfig()" in repr(cfg)
+    assert len(cfg) == 0
+    assert not hasattr(cfg, "x")
+    assert "x" not in cfg
+    assert not hasattr(cfg, "y")
+    assert "y" not in cfg
+    cfg.y = 2
+    assert len(cfg) == 1
+    assert list(cfg) == ["y"]
+    assert list(cfg.keys()) == ["y"]
+    assert list(cfg.values()) == [2]
+    assert list(cfg.items()) == [("y", 2)]
+    assert cfg.y == 2
+    assert cfg["y"] == 2
+    assert hasattr(cfg, "y")
+    assert "y" in cfg
+    del cfg["y"]
+    assert len(cfg) == 0
+    assert list(cfg) == []
+    with pytest.raises(TypeError, match="missing 1 required keyword-only"):
+        FlexibleConfig()
+    # Be strict when first creating the config object
+    with pytest.raises(TypeError, match="unexpected keyword argument 'y'"):
+        FlexibleConfig(x=1, y=2)
+
+    class FlexibleConfigWithDefault(Config, strict=False):
+        x: int = 0
+
+    assert FlexibleConfigWithDefault().x == 0
+    assert FlexibleConfigWithDefault(x=1)["x"] == 1


### PR DESCRIPTION
Recreated from original PR: https://github.com/networkx/networkx/pull/7225

This adds a global config dict for dispatching and backends. Is this what we discussed in the last networkx dispatching meeting? It allows backends to provide default configuration in `"default_config"` in the dict returned by `networkx.backend_info` entry-point. It saves this object to `nx.backend_config[backend_name]`. This config is initialized using environment variables if they are defined.

I think we should consider the fields of this config and whether we like the names, because this i...